### PR TITLE
Support nested dataset paths

### DIFF
--- a/ZFS_Dataset_Repications.sh
+++ b/ZFS_Dataset_Repications.sh
@@ -65,10 +65,11 @@ rsync_type="incremental" # set to "incremental" for dated incremental backups or
 #
 #Advanced variables you do not need to change these.
 source_path="$source_pool"/"$source_dataset"
-zfs_destination_path="$destination_pool"/"$parent_destination_dataset"/"$source_pool"_"$source_dataset"
-destination_rsync_location="$parent_destination_folder"/"$source_pool"_"$source_dataset"
+source_dataset_flat=$(echo $source_dataset | sed 's|/|_|g')
+zfs_destination_path="$destination_pool"/"$parent_destination_dataset"/"$source_pool"_"$source_dataset_flat"
+destination_rsync_location="$parent_destination_folder"/"$source_pool"_"$source_dataset_flat"
 sanoid_config_dir="/mnt/user/system/sanoid/"
-sanoid_config_complete_path="$sanoid_config_dir""$source_pool"_"$source_dataset"/
+sanoid_config_complete_path="$sanoid_config_dir""$source_pool"_"$source_dataset_flat"/
 #
 ####################
 #


### PR DESCRIPTION
This PR allows you to include `/`s (nested level directories) in your `source_dataset` variable configuration, while keeping the destination server dataset at that server's root of the zpool.
Currently, the script assumes that any dataset we want to replicate is at the root level. If one sets `$source_dataset` to a dataset at a deeper depth than the root (e.g. `zpool/my_root_dataset` vs `zpool/my/nested/dataset`) then due to the the script fails to create a dataset on the destination server, trying to create a dataset named, for example `remote_zpool/zpool_my/nested/dataset`, which is unexpected. Instead, we may expect `remote_zpool/zpool_my_nested_dataset`.
Here I add a sed substitution that replaces any `/` with `_` in the `source_dataset` user configuration on line 21, affecting only the destination share that is created.
This is useful in the case one wants to be particularly granular about what datasets they replicate.
This should not affect any pre-existing use cases, given that one has not somehow already figured out how to have forward slashes in their dataset names,

Thanks for all your hard work SpaceInvaderOne! Feel free to do whatever you like with this PR.