### PR TITLE
Fix Syncoid Flags for syncoid_mode

### DIFF
--- a/ZFS_Dataset_Repications.sh
+++ b/ZFS_Dataset_Repications.sh
@@ -337,6 +337,7 @@ zfs_replication() {
     case "${syncoid_mode}" in
       "strict-mirror")
         syncoid_flags+=("--force-delete")
+        syncoid_flags+=("--delete-target-snapshots")
         ;;
       "basic")
         # No additional flags other than -r

--- a/ZFS_Dataset_Repications.sh
+++ b/ZFS_Dataset_Repications.sh
@@ -479,6 +479,6 @@ rsync -avh --delete $link_dest "${snapshot_mount_point}/" "${rsync_destination}/
 pre_run_checks
 create_sanoid_config
 autosnap
+autoprune
 rsync_replication
 zfs_replication
-autoprune


### PR DESCRIPTION
Fixes #13 
Fixes #9 

Add `--delete-target-snapshots` flag to `syncoid_flags` when the syncoid_mode is set to `strict-mirror`.
Also reordered function calls to stop cloning of extra snapshots

This flag is defined as the following:
> With this argument snapshots which are missing on the source will be destroyed on the target. Use this if you only want to handle snapshots on the source.

Currently the only flag set is `--force-delete` which will only delete datasets, if they are not on the source.
The added flag gives the intended effect of deleting snapshots that have been removed from your source dataset.